### PR TITLE
Add shape property to PQ objects

### DIFF
--- a/navec/pq.py
+++ b/navec/pq.py
@@ -55,6 +55,10 @@ class PQ(Record):
         )
 
     @property
+    def shape(self):
+        return self.vectors, self.dim
+
+    @property
     def as_bytes(self):
         meta = self.vectors, self.dim, self.qdim, self.centroids
         meta = np.array(meta).astype(np.uint32).tobytes()

--- a/navec/tests.py
+++ b/navec/tests.py
@@ -86,3 +86,7 @@ def test_top(emb):
     assert len(sample.pq.indexes) == 2
     assert sample.sim('b', 'c') == emb.sim('b', 'c')
     assert sample.vocab.get('a') is None
+
+
+def test_shape(emb):
+    assert emb.pq.shape == (emb.pq.vectors, emb.pq.dim)


### PR DESCRIPTION
Adding `shape` property makes PQ "matrices" more compatible with numpy matrices. 
This, in turn, allows to use PQ "matrices" instead of numpy matrices in gensim library, and compress fasttext models without modifying gensim code. 