### PR TITLE
Add missing MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include * *
+prune .git


### PR DESCRIPTION
Omitting this file introduces subtle bugs down the line as the `requirements` folder isn't included when the release version is packaged to be uploaded to PyPI. This folder is required for, as an example, converting this library from a PyPI package to a conda-compliant one, a necessary step on systems that only have access to conda. Accepting this would fix one of our internal (conda-only) build pipelines and allow this package to be provided through services such as `conda-forge`.